### PR TITLE
Alteração na versão do python utilizado pelo teste

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Versão 3.10 do python não é aceita pelo teste, na realidade existe um bug onde o 3.10 é lido como 3.1 